### PR TITLE
fix typo mistake, update mkdocs theme install instruction

### DIFF
--- a/content/checkout/diy-wallet.md
+++ b/content/checkout/diy-wallet.md
@@ -77,7 +77,7 @@ If the user's pin has already been created, the response will look like this:
 
 In this step, you will need to prompt the user for the OTP (One Time Password),
 and their 3rd party transaction pin. Once those details are submitted, the
-request to verify trnasaction should be made like this:
+request to verify transaction should be made like this:
 
 The value in `token` key from the response in previous step is required
 to verify the transaction.
@@ -132,3 +132,4 @@ for more information on how to verify the transaction.
 2. If the transaction initiation API response has `pin_created = true`,
    you must display the content of `pin_created_message` key in that response
    to the user.
+

--- a/content/contribution.md
+++ b/content/contribution.md
@@ -29,6 +29,13 @@ git clone git@github.com:<YOUR_USERNAME>/khalti-docs-official-repo.git
 Install `mkdocs` using any of the methods specified in the
 [official documentation](http://www.mkdocs.org/#installation).
 
+The current theme used for mkdocs is `material`. You will need to
+install the theme as well.
+
+```bash
+pip install mkdocs-material
+```
+
 To serve the docs locally, run:
 
 ```bash

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,7 +34,7 @@ site_dir: docs
 repo_name: 'khalti/khalti-docs-official-repo'
 repo_url: 'https://github.com/khalti/khalti-docs-official-repo'
 edit_uri: 'edit/master/content/'
-copyright: 'Copyright &copy; 2017 Sparrow Pay Pvt. Ltd.'
+copyright: 'Copyright &copy; 2018 Sparrow Pay Pvt. Ltd.'
 extra:
   social:
     - type: 'github'


### PR DESCRIPTION
This PR fixes the typo show below:

`trnasaction => transaction`